### PR TITLE
Accept more pattern types

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,36 +1,50 @@
 const semaphores = new Set();
 
 export function createSemaphoreMiddleware() {
-  return ({ dispatch, getState }) => {
-    return next => action => {
-      for (let semaphore of semaphores) semaphore(action);
-      return next(action);
-    };
-  }
+  return store => next => action => {
+    for (let semaphore of semaphores) {
+      semaphore(action);
+    }
+    return next(action);
+  };
 }
 
 function normalizePattern(pattern) {
-  return typeof pattern === 'string'
-    ? (action) => action.type === pattern
-    : pattern;
+  // Match an exact action type
+  if (typeof pattern === 'string') {
+    return action => action.type === pattern;
+  }
+  // Match an array of action types
+  if (Array.isArray(pattern)) {
+    return action => pattern.includes(action.type);
+  }
+  // Match by user-provided function
+  return pattern;
 }
 
+const PATTERN_ANY = () => true;
+const PATTERN_NONE = () => false;
+
 export function semaphore(resolvePattern, rejectPattern) {
-  const resolveOn = normalizePattern(resolvePattern);
-  const rejectOn = normalizePattern(rejectPattern);
+  const resolveOn = normalizePattern(resolvePattern) || PATTERN_ANY;
+  const rejectOn = normalizePattern(rejectPattern) || PATTERN_NONE;
   let semaphoreInstance;
   return (new Promise((resolve, reject) => {
-    semaphoreInstance = (action) => {
-      if (resolveOn(action)) resolve(action);
-      else if (rejectOn && rejectOn(action)) reject(action);
+    semaphoreInstance = action => {
+      if (rejectOn(action)) {
+        reject(action);
+      }
+      else if (resolveOn(action)) {
+        resolve(action);
+      }
     };
     semaphores.add(semaphoreInstance);
   }))
-  .then((action) => {
+  .then(action => {
     semaphores.delete(semaphoreInstance);
     return action;
   })
-  .catch((error) => {
+  .catch(error => {
     semaphores.delete(semaphoreInstance);
     return Promise.reject(error);
   });


### PR DESCRIPTION
In addition to previous behavior, it now accepts:
- Arrays of action types as a resolve/reject pattern
- Undefined as a resolve pattern (resolves every time new action is dispatched)

Undefined reject pattern is effectively the same (never rejects).